### PR TITLE
Add new Samsung Tizen reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Below are the most popular platforms for Smart TV. The full list is [here](https
 
 #### Other
 * [Identification of Samsung TV models 2008-2017](http://en.tab-tv.com/?page_id=7123) - How to get screen size, matrix type, year of development, series and ohter parameters from Samsung TV model name.
+* [Tizen Studio development references](https://github.com/claromes/tizenstudio) - Documents focused on web apps for Smart TVs e Professional Monitors, based in personal researches.
 
 ### LG webOS
 #### Official resources


### PR DESCRIPTION
During a job I created a documentation to help other developers involved with Tizen Studio. Based in a license I share some PDFs provided by Samsung and share some links to helped development. It's disponible [here](https://github.com/claromes/tizenstudio).