### PR TITLE
Add Fluxcast utility for mirroring Linux desktops

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Below are the most popular platforms for Smart TV. The full list is [here](https
 
 ## Cross-platform tools
 * [smartest-tv](https://github.com/Hybirdss/smartest-tv) - CLI and MCP server for playing Netflix, YouTube, and Spotify on any smart TV by name. Deep links content across LG, Samsung, Android TV, and Roku — say "Frieren S2E8" and it plays (Python).
+* [Fluxcast](https://github.com/IlyaP358/fluxcast) - A user-friendly Python utility for mirroring Linux desktops to Smart TVs via Miracast and DLNA, supporting GNOME, KDE, and wlroots/Wayland.
 
 ## Navigation libraries
 * [lrud](https://github.com/stuart-williams/lrud) - Left, Right, Up, Down. A spatial navigation library for devices with input via directional controls.


### PR DESCRIPTION
### Link to the package
https://github.com/IlyaP358/fluxcast

### Why it should be included?
Fluxcast is a user-friendly Python utility for mirroring and casting Linux desktops to Smart TVs using native Miracast (Wi-Fi Direct) and DLNA protocols. It fills a major gap for modern Linux users by offering out-of-the-box support for Wayland compositors (including GNOME, KDE, and wlroots/Hyprland).