### PR TITLE
Add Beam-TV to Samsung Tizen > Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Below are the most popular platforms for Smart TV. The full list is [here](https
 * [Tizen Studio development references](https://github.com/claromes/tizenstudio) - Documents focused on web apps for Smart TVs e Professional Monitors, based in personal researches.
 * [TizenBrew] (https://github.com/reisxd/TizenBrew) - A way to experience modded websites and you can install newer apps without fighting with Tizen Studio
 * [TizenTube] (https://github.com/reisxd/TizenTube) - A TizenBrew module that enhances your favourite streaming websites viewing experience by removing ads and adding support for Sponsorblock.
+* [Beam-TV](https://github.com/TAGISWILD/beam-tv) - Open-source, no-account media player for Samsung Tizen TVs. Plays USB and local-network (DLNA) video/audio/subtitles directly on the TV (JavaScript).
 
 ### LG webOS
 #### Official resources


### PR DESCRIPTION
Adding [Beam-TV](https://github.com/TAGISWILD/beam-tv), an open-source (MIT) media player for Samsung Tizen TVs. It plays USB and local-network (DLNA) video/audio/subtitles directly on the TV, with no cloud dependency and no account required — filling a gap since there's currently no VLC/Kodi-equivalent client for Tizen.